### PR TITLE
Fix: Include composer on Supported Features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ And the following databases:
 - PostgreSQL
 - SQLite
 
+We detect this features following [Composer](https://getcomposer.org) guideliness, so make sure it's included in your project.
+
 ## Installation
 
 ### Prerequisites


### PR DESCRIPTION
### What does this PR do?

It includes `Composer` on "Supported Features" section. 